### PR TITLE
Require port-for>=0.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGELOG
 unreleased
 ----------
 
+Bugfix
+++++++
+
+- require `port-for>=0.6.0` which introduced the `get_port` function
+
 Misc
 ++++
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ package_dir =
     =src
 install_requires =
     pytest>=3.0.0
-    port-for
+    port-for>=0.6.0
     mirakuru>=2.0.0
     rabbitpy
 


### PR DESCRIPTION
We had `port-for==0.4.0` in our in-house PyPI mirror. `pytest-rabbitmq` installed just fine and used that version, even though the `get_port()` function was only introduced in `port-for==0.6.0`. The test suite crashed as a result.

This patch adds a constraint for 0.6.0 as the minimum version of `port-for`.