### PR TITLE
pytest-rabbitmq to define RABBITMQ_DIST_PORT value - closes #317

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 pytest = "==7.3.2"
 pika = "==1.3.2"
-port-for = "==0.6.3"
+port-for = "==0.7.0"
 mirakuru = "==2.5.1"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33fcb8f8efceee4d996639d88a236b04358f60d59711053c645bf4afb1b45291"
+            "sha256": "4df559d2bcb1dee6ff8de68baea82951b3ce35632f79be2b7444065fb7a371cb"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -64,11 +64,11 @@
         },
         "port-for": {
             "hashes": [
-                "sha256:232bd999015b7fbdf19f90f3a9298cc742252d67650108123940bfc75c6f4d4e",
-                "sha256:31860afde6cb552e1830c927def3288350c8fbbe9aea8aed8150ed9d1aa0de81"
+                "sha256:2cdd35f12919f48a3c2a78df1f64d5e0791a0bac34172253bd52a7e5a0c676c8",
+                "sha256:c8e948fd833b45af3814603fb11107ca2e58022ad6e6e24ae7428f8cd75cdd29"
             ],
             "index": "pypi",
-            "version": "==0.6.3"
+            "version": "==0.7.0"
         },
         "psutil": {
             "hashes": [

--- a/README.rst
+++ b/README.rst
@@ -86,10 +86,15 @@ You can pick which you prefer, but remember that these settings are handled in t
      - --rabbitmq-host
      - rabbitmq_host
      - 127.0.0.1
-   * - port
+   * - RABBITMQ_NODE_PORT
      - port
      - --rabbitmq-port
      - rabbitmq_port
+     - random
+   * - RABBITMQ_DIST_PORT
+     - distribution_port
+     - --rabbitmq-distribution-port
+     - rabbitmq_distribution_port
      - random
    * - rabbitmqctl path
      - ctl

--- a/newsfragments/317.feature.rst
+++ b/newsfragments/317.feature.rst
@@ -1,0 +1,6 @@
+Define RABBITMQ_DIST_PORT for rabbitmq.
+Added `--rabbitmq-distribution-port` to commandline and `rabbitmq_distribution_port` to ini configuration options.
+
+This will help both with macos port number limit (as by default Rabbitmk adds 20000 to the Node port to determine the port), and the port being already used error.
+
+This port has to be different that rabbitmq port.

--- a/pytest_rabbitmq/factories/executor.py
+++ b/pytest_rabbitmq/factories/executor.py
@@ -17,6 +17,7 @@ class RabbitMqExecutor(TCPExecutor):
         command: str,
         host: str,
         port: int,
+        distribution_port: int,
         rabbit_ctl: str,
         logpath: Path,
         path: Path,
@@ -38,6 +39,7 @@ class RabbitMqExecutor(TCPExecutor):
             "RABBITMQ_MNESIA_BASE": str(path / "mnesia"),
             "RABBITMQ_ENABLED_PLUGINS_FILE": str(plugin_path / "plugins"),
             "RABBITMQ_NODE_PORT": str(port),
+            "RABBITMQ_DIST_PORT": str(distribution_port),
             # Use the port number in node name, so multiple instances started
             # at different ports will work separately instead of clustering.
             "RABBITMQ_NODENAME": node_name or f"rabbitmq-test-{port}",

--- a/pytest_rabbitmq/plugin.py
+++ b/pytest_rabbitmq/plugin.py
@@ -29,6 +29,7 @@ _help_logsdir = "Logs directory location"
 _help_plugindir = "Directory where 'plugin' file is located"
 _help_host = "Host at which RabbitMQ will accept connections"
 _help_port = "Port at which RabbitMQ will accept connections"
+_help_distribution_port = "Port at which RabbitMQ nodes will communicate with each other"
 _help_node = "Node name for rabbitmq instance"
 
 
@@ -38,6 +39,11 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         name="rabbitmq_port",
         help=_help_port,
+        default=None,
+    )
+    parser.addini(
+        name="rabbitmq_distribution_port",
+        help=_help_distribution_port,
         default=None,
     )
     parser.addini(
@@ -73,6 +79,12 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_host,
     )
     parser.addoption("--rabbitmq-port", action="store", dest="rabbitmq_port", help=_help_port)
+    parser.addoption(
+        "--rabbitmq-distribution-port",
+        action="store",
+        dest="rabbitmq_distribution_port",
+        help=_help_distribution_port,
+    )
     parser.addoption("--rabbitmq-ctl", action="store", dest="rabbitmq_ctl", help=_help_ctl)
     parser.addoption("--rabbitmq-server", action="store", dest="rabbitmq_server", help=_help_server)
     parser.addoption(


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number