### PR TITLE
fix(pyproject.toml): Fix project entry-points name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">= 3.8"
 "Changelog" = "https://github.com/ClearcodeHQ/pytest-rabbitmq/blob/v3.0.0/CHANGES.rst"
 
 [project.entry-points."pytest11"]
-pytest_redis = "pytest_rabbitmq.plugin"
+pytest_rabbitmq = "pytest_rabbitmq.plugin"
 
 [build-system]
 requires = ["setuptools >= 61.0.0", "wheel"]


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number