### PR TITLE
Entrypoint name error

### DIFF
--- a/newsfragments/349.bugfix.rst
+++ b/newsfragments/349.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed rabbitmq entrypoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">= 3.8"
 "Changelog" = "https://github.com/ClearcodeHQ/pytest-rabbitmq/blob/v3.0.0/CHANGES.rst"
 
 [project.entry-points."pytest11"]
-pytest_redis = "pytest_rabbitmq.plugin"
+pytest_rabbitmq = "pytest_rabbitmq.plugin"
 
 [build-system]
 requires = ["setuptools >= 61.0.0", "wheel"]


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number