### PR TITLE
fix: fix logsdir config

### DIFF
--- a/newsfragments/354.bugfix.rst
+++ b/newsfragments/354.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes logdir config option reading.

--- a/pytest_rabbitmq/factories/process.py
+++ b/pytest_rabbitmq/factories/process.py
@@ -75,11 +75,12 @@ def get_config(request: FixtureRequest) -> RabbitMQConfig:
 
     port = get_conf_option("port")
     distribution_port = get_conf_option("distribution_port")
+    logsdir = get_conf_option("logsdir")
     config: RabbitMQConfig = {
         "host": get_conf_option("host"),
         "port": int(port) if port else None,
         "distribution_port": int(distribution_port) if distribution_port else None,
-        "logsdir": Path(get_conf_option("logsdir")),
+        "logsdir": Path(logsdir) if logsdir else None,
         "server": get_conf_option("server"),
         "ctl": get_conf_option("ctl"),
         "node": get_conf_option("node"),


### PR DESCRIPTION
No `logsdir`in either config or CLI options, and yet `get_config` returns `Path(".")` for the key, causing logs to be output in the project directory while testing. This is because `request.config.getini("rabbitmq_logsdir")` returns `""` instead of `None`, and fun fact:

```python
>>> from pathlib import Path
>>> Path('')
PosixPath('.')
```

Temporary workaround on my end, until this is released:

```python
def pytest_addoption(parser: Parser) -> None:
    """Configure the parser."""
    # We want to override the logsdir default because of a bug in
    # the pytest-rabbitmq config parser.
    parser.addini(
        name='rabbitmq_logsdir',
        help='logsdir override for pytest-rabbitmq',
        default=gettempdir(),
    )
```