### PR TITLE
fix: set HOME env var when not present in environment

### DIFF
--- a/pytest_rabbitmq/factories/executor.py
+++ b/pytest_rabbitmq/factories/executor.py
@@ -1,5 +1,6 @@
 """RabbitMQ Executor."""
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -31,7 +32,7 @@ class RabbitMqExecutor(TCPExecutor):
         :param port: port under which rabbitmq runs
         :param rabbit_ctl: rabbitctl location
         :param logpath:
-        :param path: Path containing rabbitmq'a mnesia na plugins
+        :param path: Path containing rabbitmq's mnesia and plugins
         :param node_name: RabbitMQ node name
         """
         envvars = {
@@ -44,6 +45,11 @@ class RabbitMqExecutor(TCPExecutor):
             # at different ports will work separately instead of clustering.
             "RABBITMQ_NODENAME": node_name or f"rabbitmq-test-{port}",
         }
+        # RabbitMQ (Erlang runtime) requires HOME to be set.
+        # In environments like tox, HOME is stripped from the environment.
+        # Set HOME to the temporary directory if it is not already set.
+        if "HOME" not in os.environ:
+            envvars["HOME"] = str(path)
         super().__init__(command, host, port, timeout=60, envvars=envvars)
         self.rabbit_ctl = rabbit_ctl
 


### PR DESCRIPTION
## Problem

RabbitMQ's Erlang runtime requires the `HOME` environment variable to be set. In stripped environments like `tox` (which unsets all env vars), the `rabbitmq-server` process fails with:

```
mirakuru.exceptions.ProcessExitedWithError: The process invoked by the
<pytest_rabbitmq.factories.process.RabbitMqExecutor: "rabbitmq-server">
executor has exited with a non-zero code: 1.

Captured stderr setup:
erlexec: HOME must be set
```

Users currently need a workaround in `tox.ini`:
```ini
setenv = HOME = {envtmpdir}
```

## Fix

When `HOME` is not already present in `os.environ`, set it to the temporary directory path (`path` parameter) via `envvars` in `RabbitMqExecutor.__init__`. This is the same directory that RabbitMQ already uses for its runtime data (`RABBITMQ_MNESIA_BASE`), so it's a safe and appropriate fallback.

The fix is minimal — only 3 lines added to `executor.py`:

```python
if "HOME" not in os.environ:
    envvars["HOME"] = str(path)
```

## Related Issues

Fixes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the RabbitMQ executor would fail in environments where the HOME environment variable is stripped or missing.

* **Documentation**
  * Corrected typos in parameter documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dbfixtures/pytest-rabbitmq/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->